### PR TITLE
put back in vnet and subnet prefix as they should be there

### DIFF
--- a/articles/application-gateway/application-gateway-create-gateway-cli.md
+++ b/articles/application-gateway/application-gateway-create-gateway-cli.md
@@ -121,7 +121,9 @@ az network application-gateway create \
 --location eastus \
 --resource-group AdatumAppGatewayRG \
 --vnet-name AdatumAppGatewayVNET \
+---vnet-address-prefix 10.0.0.0/16 \
 --subnet Appgatewaysubnet \
+---subnet-address-prefix 10.0.0.0/28 \
 --servers 10.0.0.4 10.0.0.5 \
 --cert-file /mnt/c/Users/username/Desktop/application-gateway/fabrikam.pfx \
 --cert-password P@ssw0rd \


### PR DESCRIPTION
Was a bug in the CLI that has been corrected.